### PR TITLE
Remove slack webhook url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 alertmanager.yaml
 ```yaml
 global:
-  slack_api_url: 'https://hooks.slack.com/services/TGA8024LF/BG8JMKBR7/waIyk9aPH3p9s'
+  slack_api_url: 'https://hooks.slack.com/services/../../...'
 
 route:
   receiver: 'slack-notifications'

--- a/alertManager/alertmanager.yaml
+++ b/alertManager/alertmanager.yaml
@@ -1,6 +1,6 @@
 global:
   resolve_timeout: 10m
-  slack_api_url: 'https://hooks.slack.com/services/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'
+  slack_api_url: 'https://hooks.slack.com/services/../../...'
 
 route:
   receiver: 'slack-notifications'


### PR DESCRIPTION
Though this url belong to a demo workspace, It was a mistake